### PR TITLE
fix(api): add support for API routes with namespace

### DIFF
--- a/src/handlers/core/route/api.ts
+++ b/src/handlers/core/route/api.ts
@@ -27,7 +27,9 @@ export const handleApiReq = (
   );
 
   if (!missingExpectedBasePath) {
-    const nonDynamic = apis.nonDynamic[normalisedUri];
+    // @ts-ignore: manifest is actually a PageManifest cast to an ApiManifest
+    const namespace = manifest.namespace;
+    const nonDynamic = apis.nonDynamic[normalisedUri.replace(namespace, '')];
     if (nonDynamic) {
       return {
         isApi: true,

--- a/src/handlers/core/route/index.ts
+++ b/src/handlers/core/route/index.ts
@@ -175,13 +175,9 @@ export const routeDefault = async (
   const nextStaticFile = handleNextStaticFiles(uri);
   const isNextStaticFile = !!nextStaticFile;
 
-  let isApi = uri.startsWith(`/api`);
-
-  if (manifest.namespace) {
-    const namespaceApiMatch = new RegExp(`\\w${manifest.namespace}/api`);
-
-    isApi = namespaceApiMatch.test(uri);
-  }
+  const isApi = manifest.namespace
+    ? uri.startsWith(`${manifest.namespace}/api`)
+    : uri.startsWith(`/api`);
 
   if (isApi) {
     // This api request handling shouldn't be done here


### PR DESCRIPTION
- \\w${manifest.namespace}/api does not match with /news/api due to the word character match.
- remove namespace from normalisedUri before api lookup

A quick fix to have API routes working with namespaces. A more thorough look is needed at namespacing and routing. We might need to add the namespace to the basepath so the `normalise` helper actually removes the namespace form the uri.