### PR TITLE
fix: implement missing function res.getHeader

### DIFF
--- a/src/handlers/lambda/default-handler.ts
+++ b/src/handlers/lambda/default-handler.ts
@@ -103,6 +103,9 @@ export const handleRegeneration = async (event: SQSEvent): Promise<void> => {
           end: () => {
             console.log('end');
           },
+          getHeader: () => {
+            console.log('getHeader');
+          },
         },
       );
 


### PR DESCRIPTION
Implements missing function res.getHeader on regeneration. Solves error:

```
2022-04-07T15:29:59.578Z 8eb62bc2-be0d-53c3-9442-710bbbaa71a1 
ERROR Unhandled error during request: 
TypeError: res.getHeader is not a function at Object.clearPreviewData (/var/task/chunks/989.js:65477:26) 
at Object.tryGetPreviewData (/var/task/chunks/989.js:65601:21) 
at Module.renderReqToHTML (/var/task/chunks/989.js:40938:44) 
at async 	 (/var/task/index.js:20737:46) 
at async regenerationHandler (/var/task/index.js:102564:34) 
at async /var/task/index.js:102752:9 at async Promise.all (index 4) 
at async handleRegeneration (/var/task/index.js:102740:5) 
at async Runtime.handler (/var/task/index.js:102767:9)
```