### PR TITLE
fix: implement missing function res.setHeader

### DIFF
--- a/src/handlers/lambda/default-handler.ts
+++ b/src/handlers/lambda/default-handler.ts
@@ -106,6 +106,9 @@ export const handleRegeneration = async (event: SQSEvent): Promise<void> => {
           getHeader: () => {
             console.log('getHeader');
           },
+          setHeader: () => {
+            console.log('setHeader');
+          },
         },
       );
 


### PR DESCRIPTION
Fixes the error:

```
ERROR 
Unhandled Promise Rejection {"errorType":"Runtime.UnhandledPromiseRejection","errorMessage":"TypeError: res.setHeader is not a function","reason":{"errorType":"TypeError","errorMessage":"res.setHeader is not a function","stack":["TypeError: res.setHeader is not a function"," at Object.sendRenderResult (/var/task/chunks/722.js:68183:13)"," 
at Module.renderReqToHTML (/var/task/chunks/722.js:40998:43)"," 
at processTicksAndRejections (internal/process/task_queues.js:95:5)"," 
at async renderPageToHtml (/var/task/index.js:20757:17)"," 
at async regenerationHandler (/var/task/index.js:102564:34)"," 
at async /var/task/index.js:102755:9"," 
at async Promise.all (index 0)"," 
at async handleRegeneration (/var/task/index.js:102740:5)"," 
at async Runtime.handler (/var/task/index.js:102770:9)"]},"promise":{},"stack":["Runtime.UnhandledPromiseRejection: TypeError: res.setHeader is not a function"," 
at process.<anonymous> (/var/runtime/index.js:35:15)"," 
at process.emit (events.js:400:28)"," 
at processPromiseRejections (internal/process/promises.js:245:33)"," at processTicksAndRejections (internal/process/task_queues.js:96:32)"]}
```

Not ideal, but as the regeneration happens on a Lambda worker and nothing is done with the response, this should at least get us something up and running.