### PR TITLE
feat: add custom headers to allow list

### DIFF
--- a/src/cdk/props.ts
+++ b/src/cdk/props.ts
@@ -8,6 +8,7 @@ export interface Props extends StackProps {
    */
   nextjsCDKBuildOutDir: string;
   domain?: Domain;
+  customHeaders?: string[];
 }
 
 export interface Domain {

--- a/src/cdk/strategies/NextJSAPIGateway.ts
+++ b/src/cdk/strategies/NextJSAPIGateway.ts
@@ -19,11 +19,7 @@ import {
 
 import { Props } from '../props';
 import { LambdaHandler, logger } from '../../common';
-import {
-  readAssetsDirectory,
-  reduceInvalidationPaths,
-  readInvalidationPathsFromManifest,
-} from '../utils';
+import { readAssetsDirectory } from '../utils';
 import { pathToPosix } from '../../build/lib';
 import { NextJSConstruct } from './NextJSConstruct';
 
@@ -168,7 +164,10 @@ export class NextJSAPIGateway extends NextJSConstruct {
         {
           cachePolicyName: `next-lambda-cache-${id}`,
           queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
-          headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+          headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
+            'authorization',
+            ...(props.customHeaders ? props.customHeaders : []),
+          ),
           cookieBehavior: {
             behavior: 'all',
           },

--- a/src/cdk/strategies/NextJSAtEdge.ts
+++ b/src/cdk/strategies/NextJSAtEdge.ts
@@ -49,7 +49,7 @@ export class NextJSAtEdge extends NextJSConstruct {
     }
 
     this.createCert(id, props.domain);
-    this.createEdgeDistribution(id, props.domain);
+    this.createEdgeDistribution(id, props.domain, props.customHeaders);
     this.createHostedZone(id, props.domain);
     this.uploadNextAssets();
 
@@ -95,7 +95,11 @@ export class NextJSAtEdge extends NextJSConstruct {
     return this.edgeLambdaRole;
   }
 
-  private createEdgeDistribution(id: string, domain?: Domain) {
+  private createEdgeDistribution(
+    id: string,
+    domain?: Domain,
+    customHeaders?: string[],
+  ) {
     if (!this.bucket || !this.defaultNextLambda) return;
 
     this.bucket.grantRead(
@@ -152,7 +156,10 @@ export class NextJSAtEdge extends NextJSConstruct {
       {
         cachePolicyName: `next-lambda-cache-${id}`,
         queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
-        headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+        headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
+          'authorization',
+          ...(customHeaders ? customHeaders : []),
+        ),
         cookieBehavior: {
           behavior: 'all',
         },

--- a/tests/unit/stack/edge/__snapshots__/edge-lambda.test.ts.snap
+++ b/tests/unit/stack/edge/__snapshots__/edge-lambda.test.ts.snap
@@ -1001,7 +1001,10 @@ Object {
             "EnableAcceptEncodingBrotli": true,
             "EnableAcceptEncodingGzip": true,
             "HeadersConfig": Object {
-              "HeaderBehavior": "none",
+              "HeaderBehavior": "whitelist",
+              "Headers": Array [
+                "authorization",
+              ],
             },
             "QueryStringsConfig": Object {
               "QueryStringBehavior": "all",


### PR DESCRIPTION
Enables the addition of custom headers to be forwarded to origin - API Gateway or Lambda Edge thru the CDK props.

`authorization` is added by default.